### PR TITLE
Remove non needed urls from template

### DIFF
--- a/src/Hedin.UI.Template.Server/appsettings.json
+++ b/src/Hedin.UI.Template.Server/appsettings.json
@@ -8,12 +8,6 @@
   "AllowedHosts": "*",
   "HedinUI": {
     "AppTitle": "Your app name", // Applies to PageTitle using HUIPage, AppSwitcher and more.
-    // Below url settings for the app switcher
-    "ManagementPortalUrl": "https://managementportal.ims-dev.external.hedinit.io/",
-    "DealerPortalUrl": "https://dealerportal.ims-dev.external.hedinit.io/",
-    "ConnectUrl": "https://hedin-connect-web.fleet-dev.hedinit.io/",
-    "PolarisUrl": "https://polaris-qa.hedinit.com/",
-    "MechMateUrl": "https://mech-mate.retail-test.internal.hedinit.io/",
     "ShowDevEnvWarning": false, //Will show a top banner for dev/stage/test, should not be true in prod
     "GoogleMapsApiKey": "" //Required with HUIMaps component
   }


### PR DESCRIPTION
🔧 (appsettings.json): remove unused URL settings related to app switcher to clean up configuration file and ensure only necessary configuration keys are included