### PR TITLE
Persist dark mode preference in local storage

### DIFF
--- a/src/Hedin.UI.Demo/Shared/MainLayout.razor
+++ b/src/Hedin.UI.Demo/Shared/MainLayout.razor
@@ -2,6 +2,7 @@
 @inject IHUIPageHelper HUIPageHelper
 @inject IOptions<TitleService> TitleService
 @inject AiMessageStateService MessageService
+@inject ILocalStorageSettingsService LocalStorageSettings
 
 <HUIThemeProvider Theme="_currentTheme" />
 <MudPopoverProvider />
@@ -9,6 +10,8 @@
 <MudSnackbarProvider />
 <PageTitle>@TitleService.Value.AppTitle</PageTitle>
 
+@if (_themeLoaded)
+{
 <MudLayout>
     <HUIAppBar MenuButtonVisibilityChanged="v => _drawerLeftOpen = v" MenuButtonClicked="DrawerToggle"
     LogoBrandSrc="@(_darkMode ? "./hedin-ui_light.svg" : "./hedin-ui_dark.svg")" AppDrawerItems="_appDrawerItems"
@@ -63,6 +66,7 @@
 
     </MudDrawer>
 </MudLayout>
+}
 
 @code {
     Chat? chat;
@@ -70,6 +74,7 @@
 
     private string _mainContainerClass => "px-3" + (_drawerLeftOpen ? " pl-md-0" : "");
     private bool _darkMode = true;
+    private bool _themeLoaded = false;
     private bool _animationOngoing = false;
 
     private MudTheme _currentTheme => _darkMode
@@ -95,7 +100,13 @@
     private RightPane _activeRightPane = RightPane.None;
 
     private void DrawerToggle() => _drawerLeftOpen = !_drawerLeftOpen;
-    private void HandleThemeButtonClick() => _darkMode = !_darkMode;
+    private async Task HandleThemeButtonClick()
+    {
+        _darkMode = !_darkMode;
+        var settings = await LocalStorageSettings.GetSettings();
+        settings.Theme = _darkMode ? ThemeMode.Dark : ThemeMode.Light;
+        await LocalStorageSettings.SetSettings(settings);
+    }
 
     private void HandleMessageReadClick(HUIInformationMessageModel message) => message.MarkAsRead();
     private void HandleMessageArchivedClick(HUIInformationMessageModel message) => message.Archive();
@@ -124,6 +135,18 @@
     {
         _menuItems = await HUIPageHelper.GetMenuItems([typeof(App).Assembly]);
         MessageService.OnMessage += async msg => await HandleAiMessage(msg);
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            // Load theme preference from localStorage
+            var settings = await LocalStorageSettings.GetSettings();
+            _darkMode = settings.Theme == ThemeMode.Dark;
+            _themeLoaded = true;
+            StateHasChanged();
+        }
     }
 
     void ToggleNotifications()

--- a/src/Hedin.UI/Hedin.UI.csproj
+++ b/src/Hedin.UI/Hedin.UI.csproj
@@ -12,7 +12,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <SignAssembly>False</SignAssembly>
     <DelaySign>False</DelaySign>
-    <Version>1.0.3</Version>
+    <Version>1.0.4</Version>
     <NeutralLanguage>en-001</NeutralLanguage>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <RepositoryUrl>https://github.com/hedinbil/hedin-ui</RepositoryUrl>

--- a/src/Hedin.UI/Services/HUILocalStorageSettingsService.cs
+++ b/src/Hedin.UI/Services/HUILocalStorageSettingsService.cs
@@ -2,13 +2,19 @@
 
 namespace Hedin.UI.Services
 {
-
-    internal class HUILocalStorageSetting
+    public enum ThemeMode
     {
-        public List<HUILocalStorageTableSetting> TableSettings { get; set; } = new();
+        Light,
+        Dark
     }
 
-    internal class HUILocalStorageTableSetting
+    public class HUILocalStorageSetting
+    {
+        public List<HUILocalStorageTableSetting> TableSettings { get; set; } = new();
+        public ThemeMode Theme { get; set; } = ThemeMode.Dark;
+    }
+
+    public class HUILocalStorageTableSetting
     {
         public string TableId { get; set; }
         public Dictionary<string, int> ColumnOrder { get; set; }
@@ -16,14 +22,14 @@ namespace Hedin.UI.Services
     }
 
 
-    internal interface ILocalStorageSettingsService
+    public interface ILocalStorageSettingsService
     {
         public Task<HUILocalStorageSetting> GetSettings();
         public Task SetSettings(HUILocalStorageSetting settings);
         public Task ClearSettings();
     }
 
-    internal class LocalStorageSettingsService : ILocalStorageSettingsService
+    public class LocalStorageSettingsService : ILocalStorageSettingsService
     {
         private const string _settingsName = "hui"; 
         private ILocalStorageService _localStorageService;


### PR DESCRIPTION
MainLayout now loads and saves the dark mode setting using ILocalStorageSettingsService, ensuring user theme preference is retained across sessions. HUILocalStorageSetting and related service/interface classes are made public and a DarkMode property is added to support this functionality.

Refactor dark mode to use ThemeMode enum

Replaced the boolean DarkMode property with a ThemeMode enum in local storage settings for improved clarity and extensibility. Updated MainLayout.razor and HUILocalStorageSettingsService to use the new Theme property. Bumped package version to 1.0.4.


Closes #8 