### PR TITLE
1.0.5 - Disabled HUIMenuItem

### DIFF
--- a/src/Hedin.UI.Demo/Hedin.UI.Demo.csproj
+++ b/src/Hedin.UI.Demo/Hedin.UI.Demo.csproj
@@ -45,18 +45,18 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="AspNetCore.SassCompiler" Version="1.86.2" />
+        <PackageReference Include="AspNetCore.SassCompiler" Version="1.93.2" />
         <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
-        <PackageReference Include="Azure.Identity" Version="1.13.2" />
+        <PackageReference Include="Azure.Identity" Version="1.16.0" />
         <PackageReference Include="Brism" Version="1.0.1" />
         <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.4" />
-        <PackageReference Include="MudBlazor.Markdown" Version="8.6.0" />
-      <PackageReference Include="Azure.AI.OpenAI" Version="2.2.0-beta.4" />
-      <PackageReference Include="Azure.Search.Documents" Version="11.6.0" />
+        <PackageReference Include="MudBlazor.Markdown" Version="8.11.0" />
+      <PackageReference Include="Azure.AI.OpenAI" Version="2.3.0-beta.2" />
+      <PackageReference Include="Azure.Search.Documents" Version="11.6.1" />
       <PackageReference Include="ModelContextProtocol" Version="0.2.0-preview.3" />
       <PackageReference Include="ModelContextProtocol.AspNetCore" Version="0.2.0-preview.3" />
-      <PackageReference Include="Microsoft.SemanticKernel" Version="1.55.0" />
-      <PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureOpenAI" Version="1.55.0" />
+      <PackageReference Include="Microsoft.SemanticKernel" Version="1.65.0" />
+      <PackageReference Include="Microsoft.SemanticKernel.Connectors.AzureOpenAI" Version="1.65.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Hedin.UI.Demo/Pages/Components/NavMenu/NavMenuDrawer/Examples/Example1.razor
+++ b/src/Hedin.UI.Demo/Pages/Components/NavMenu/NavMenuDrawer/Examples/Example1.razor
@@ -36,7 +36,8 @@
                         "Translations",
                         "/translations",
                         null,
-                        icon: Icons.Material.Filled.Translate)
+                        icon: Icons.Material.Filled.Translate,
+                        disabled: true)
                 ]
             },
             new HUIMenuItem(
@@ -79,6 +80,7 @@
                 "Guidelines",
                 "/guidelines",
                 null,
+                disabled: true,
                 icon: Icons.Material.Filled.ListAlt
             )
         ];

--- a/src/Hedin.UI.Demo/Pages/Components/NavMenu/NavMenuHorizontal/Examples/Default.razor
+++ b/src/Hedin.UI.Demo/Pages/Components/NavMenu/NavMenuHorizontal/Examples/Default.razor
@@ -6,7 +6,7 @@
     private List<HUIMenuItem> menuItems = new List<HUIMenuItem>
         {
             new HUIMenuItem("Menu option 1", "url1", ""),
-            new HUIMenuItem("Menu option 2", "url2", ""),
+            new HUIMenuItem("Menu option 2", "url2", "", disabled: true),
             new HUIMenuItem("Menu option 3", "url3", ""),
         };
 }

--- a/src/Hedin.UI.Template.Server/Hedin.UI.Template.Server.csproj
+++ b/src/Hedin.UI.Template.Server/Hedin.UI.Template.Server.csproj
@@ -10,7 +10,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hedin.UI" Version="1.0.0" />
+    <PackageReference Include="Hedin.UI" Version="1.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Hedin.UI.Tests/Hedin.UI.Tests.csproj
+++ b/src/Hedin.UI.Tests/Hedin.UI.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="bunit" Version="1.40.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/src/Hedin.UI/Components/NavMenu/HUINavMenu.razor
+++ b/src/Hedin.UI/Components/NavMenu/HUINavMenu.razor
@@ -159,7 +159,7 @@
 
     private RenderFragment GetLinkFragment(HUIMenuItem menuItem)
     {
-        return @<MudNavLink Href="@menuItem.Url" Match="GetMatchLink(menuItem)">@Localizer[menuItem.DisplayName]</MudNavLink>;
+        return @<MudNavLink Href="@menuItem.Url" Match="GetMatchLink(menuItem)" Disabled="@menuItem.Disabled">@Localizer[menuItem.DisplayName]</MudNavLink>;
     }
 
     private void HandleGroupExpansionChanged(bool expanded, HUIMenuItem menuItem)

--- a/src/Hedin.UI/Components/NavMenu/HUINavMenuDrawer.razor
+++ b/src/Hedin.UI/Components/NavMenu/HUINavMenuDrawer.razor
@@ -150,12 +150,21 @@
         <MudNavLink Match="@(menuItem.Url == "/" ? NavLinkMatch.All : NavLinkMatch.Prefix)"
                     Href="@menuItem.Url"
                     Icon="@menuItem.Icon"
+                    Disabled="@menuItem.Disabled"
                     Style="transition: none;">
             @menuItem.DisplayName
         </MudNavLink>
-
-            @* collapsed state: show arrow that opens on hover *@
-        @if (submenu != null && !menuItem.IsExpanded)
+        @if (menuItem.Disabled)
+        {
+            <div class="expanded-menu-item expanded-menu-item-disabled">
+                <span style="display:flex; align-items: center; gap: 8px">
+                    @menuItem.DisplayName
+                    @* <MudIcon Icon="@Icons.Material.Filled.KeyboardArrowDown" Size="Size.Small" /> *@
+                </span>
+            </div>
+        }
+        @* collapsed state: show arrow that opens on hover *@
+        else if (submenu != null && !menuItem.IsExpanded)
     {
         <div class="expanded-menu-item"
              @onmouseenter="() => menuItem.IsExpanded = true"
@@ -188,7 +197,7 @@
     private RenderFragment GetSubItem(HUIMenuItem menuItem) => @<div @onclick="() => ResetMenuItem(menuItem)">
         @if (!string.IsNullOrEmpty(menuItem.Url))
     {
-        <MudNavLink Match="NavLinkMatch.Prefix" Href="@menuItem.Url">
+        <MudNavLink Match="NavLinkMatch.Prefix" Href="@menuItem.Url" Disabled="@menuItem.Disabled">
             @menuItem.DisplayName
         </MudNavLink>
     }

--- a/src/Hedin.UI/Components/NavMenu/HUINavMenuDrawer.razor.scss
+++ b/src/Hedin.UI/Components/NavMenu/HUINavMenuDrawer.razor.scss
@@ -48,6 +48,9 @@
     width: max-content;
     border-top-right-radius: 8px;
     border-bottom-right-radius: 8px;
+    &.expanded-menu-item-disabled{
+      color: var(--mud-palette-text-disabled);
+    }
   }
 
   .expanded-menu-item:hover .submenu {

--- a/src/Hedin.UI/Components/NavMenuHorizontal/HUINavMenuHorizontal.razor
+++ b/src/Hedin.UI/Components/NavMenuHorizontal/HUINavMenuHorizontal.razor
@@ -65,6 +65,7 @@
     {
         return @<MudTabPanel
                     Class="px-6"
+                    Disabled="menuItem.Disabled"
                     OnClick="() => HandleOnTabClick(menuItem)"
                     ToolTip="@menuItem.Tooltip"
                     Icon="@menuItem.Icon">

--- a/src/Hedin.UI/Components/NavMenuHorizontal/HUINavMenuHorizontal.razor.scss
+++ b/src/Hedin.UI/Components/NavMenuHorizontal/HUINavMenuHorizontal.razor.scss
@@ -50,6 +50,9 @@
         &:has(.mud-badge-root):not(:has(.mud-badge-dot)) {
             margin-right: 15px !important;
         }
+        &.mud-disabled{
+          color: var(--mud-palette-text-disabled);
+        }
     }
 
     .mud-tab.mud-tab-active {

--- a/src/Hedin.UI/Hedin.UI.csproj
+++ b/src/Hedin.UI/Hedin.UI.csproj
@@ -12,7 +12,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <SignAssembly>False</SignAssembly>
     <DelaySign>False</DelaySign>
-    <Version>1.0.4</Version>
+    <Version>1.0.5</Version>
     <NeutralLanguage>en-001</NeutralLanguage>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <RepositoryUrl>https://github.com/hedinbil/hedin-ui</RepositoryUrl>
@@ -41,12 +41,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.SassCompiler" Version="1.86.2" />
-    <PackageReference Include="Blazor-ApexCharts" Version="5.1.0" />
+    <PackageReference Include="AspNetCore.SassCompiler" Version="1.93.2" />
+    <PackageReference Include="Blazor-ApexCharts" Version="6.0.2" />
     <PackageReference Include="Blazored.LocalStorage" Version="4.5.0" />
     <PackageReference Include="ClosedXML" Version="0.105.0" />
-    <PackageReference Include="FluentValidation" Version="11.11.0" />
-    <PackageReference Include="MudBlazor" Version="8.11.0" />
+    <PackageReference Include="FluentValidation" Version="12.0.0" />
+    <PackageReference Include="MudBlazor" Version="8.13.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.4" />
   </ItemGroup>

--- a/src/Hedin.UI/Helpers/PageSettingsAttribute.cs
+++ b/src/Hedin.UI/Helpers/PageSettingsAttribute.cs
@@ -27,6 +27,9 @@ namespace Hedin.UI
         public bool IsExpanded { get; set; }
         public string Policy { get; set; }
         public int Order { get; set; }
+        
+        public bool Disabled { get; set; }
+        
         public bool HasExpandedChild { get; set; }
 
         public string? Tooltip { get; set; }
@@ -47,7 +50,8 @@ namespace Hedin.UI
             string? tooltip = null,
             string? badgeData = null, 
             Color badgeColor = Color.Default,
-            Severity? dot = null)
+            Severity? dot = null,
+            bool disabled = false)
         {
             DisplayName = displayName;
             Url = url;
@@ -59,6 +63,7 @@ namespace Hedin.UI
             BadgeData = badgeData;
             BadgeColor = badgeColor;
             Dot = dot;
+            Disabled = disabled;
         }
     }
 }


### PR DESCRIPTION
Added the possibility to disable HUIMenuItems, mainly for the Horizontal implementation.
<img width="590" height="209" alt="image" src="https://github.com/user-attachments/assets/b79edf8f-cfdd-40ba-9d8b-0076c3a2d866" />

But also the drawer can be disabled
<img width="356" height="468" alt="image" src="https://github.com/user-attachments/assets/33dd3821-9362-4d7d-a451-1ef0cbf67f4d" />
<img width="302" height="245" alt="image" src="https://github.com/user-attachments/assets/7fcb60cd-16be-464e-ae98-2f0ff6ea34fa" />

