### PR TITLE
DataGrid: Add pager localization and page size option, fix GetPager()…

### DIFF
--- a/src/Hedin.UI.Demo/Pages/Components/DataGrid/DataGrid.razor
+++ b/src/Hedin.UI.Demo/Pages/Components/DataGrid/DataGrid.razor
@@ -8,4 +8,7 @@
     <DemoExample ComponentType="typeof(Hedin.UI.Demo.Pages.Components.DataGrid.Examples.DenseGrid)">
         <MudText>Dense grid. Used in smaller portions of the screen.</MudText>
     </DemoExample>
+    <DemoExample ComponentType="typeof(Hedin.UI.Demo.Pages.Components.DataGrid.Examples.LocalizedPagerGrid)">
+        <MudText>Localized pager text using PagerRowsPerPageString, PagerInfoFormat, and PagerAllItemsText.</MudText>
+    </DemoExample>
 </DemoPageLayout>

--- a/src/Hedin.UI.Demo/Pages/Components/DataGrid/Examples/LocalizedPagerGrid.razor
+++ b/src/Hedin.UI.Demo/Pages/Components/DataGrid/Examples/LocalizedPagerGrid.razor
@@ -1,0 +1,40 @@
+<HUIDataGrid Items="cars" T="Car" Height="340px"
+             PagerRowsPerPageString="Rader per sida:"
+             PagerInfoFormat="{first_item}-{last_item} av {all_items}"
+             PagerAllItemsText="Alla"
+             PagerPageSizeOptions="new[] { 10, 25, 50, int.MaxValue }">
+    <Columns>
+        <PropertyColumn Property="x => x.OrderNo" Title="Order number"/>
+        <PropertyColumn Property="x => x.Model"/>
+        <PropertyColumn Property="x => x.RegNo" Title="Reg number"/>
+        <PropertyColumn Property="x => x.Status"/>
+    </Columns>
+</HUIDataGrid>
+
+@code {
+    public List<Car> cars = new();
+
+    protected override void OnInitialized()
+    {
+        for (int i = 0; i < 100; i++)
+        {
+            cars.Add(new Car($"R1542A{i}", "Megan E-Tech Electric", $"AAA00{i}", "Factory order"));
+        }
+    }
+
+    public class Car
+    {
+        public string OrderNo { get; set; }
+        public string Model { get; set; }
+        public string RegNo { get; set; }
+        public string Status { get; set; }
+
+        public Car(string orderNo, string model, string regNo, string status)
+        {
+            OrderNo = orderNo;
+            Model = model;
+            RegNo = regNo;
+            Status = status;
+        }
+    }
+}

--- a/src/Hedin.UI/Components/DataGrid/HUIDataGrid.razor
+++ b/src/Hedin.UI/Components/DataGrid/HUIDataGrid.razor
@@ -226,6 +226,26 @@
     /// Overrides the default pager when provided.
     /// </summary>
     [Parameter] public RenderFragment PagerContent { get; set; }
+
+    /// <summary>
+    /// Localized label for the rows-per-page selector.
+    /// Defaults to MudBlazor's built-in text when not set.
+    /// </summary>
+    [Parameter] public string? PagerRowsPerPageString { get; set; }
+
+    /// <summary>
+    /// Format string for the page info label.
+    /// Supports {first_item}, {last_item}, and {all_items} placeholders.
+    /// Example: "{first_item}-{last_item} av {all_items}"
+    /// Defaults to MudBlazor's built-in format when not set.
+    /// </summary>
+    [Parameter] public string? PagerInfoFormat { get; set; }
+
+    /// <summary>
+    /// Text shown in the page-size dropdown for "All items" (int.MaxValue).
+    /// Defaults to MudBlazor's built-in text when not set.
+    /// </summary>
+    [Parameter] public string? PagerAllItemsText { get; set; }
     
     /// <summary>
     /// Content displayed when no records are available.
@@ -382,6 +402,13 @@
     /// Affects pagination and performance.
     /// </summary>
     [Parameter] public int RowsPerPage { get; set; } = 10;
+
+    /// <summary>
+    /// Available page size options in the pager dropdown.
+    /// Add int.MaxValue to include an "All" option (use PagerAllItemsText to localize its label).
+    /// Defaults to 10, 25, 50, 100 when not set.
+    /// </summary>
+    [Parameter] public int[] PagerPageSizeOptions { get; set; } = [10, 25, 50, 100];
     
     /// <summary>
     /// Event callback when the rows per page changes.
@@ -544,7 +571,15 @@
         StateHasChanged();
     }
 
-    private RenderFragment? GetPager() => ShowPager ? @<MudDataGridPager T="T" Class="hui-datagrid-pager" /> : null;
+    private RenderFragment? GetPager() =>
+        PagerContent ?? (ShowPager
+            ? @<MudDataGridPager T="T"
+                   Class="hui-datagrid-pager"
+                   RowsPerPageString="@(PagerRowsPerPageString ?? string.Empty)"
+                   InfoFormat="@(PagerInfoFormat ?? string.Empty)"
+                   AllItemsText="@(PagerAllItemsText ?? string.Empty)"
+                   PageSizeOptions="PagerPageSizeOptions" />
+            : null);
     /// <summary>
     /// Force the state of the component to change.
     /// </summary>

--- a/src/Hedin.UI/Hedin.UI.csproj
+++ b/src/Hedin.UI/Hedin.UI.csproj
@@ -12,7 +12,7 @@
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <SignAssembly>False</SignAssembly>
     <DelaySign>False</DelaySign>
-    <Version>1.1.1</Version>
+    <Version>1.1.2</Version>
     <NeutralLanguage>en-001</NeutralLanguage>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <RepositoryUrl>https://github.com/hedinbil/hedin-ui</RepositoryUrl>


### PR DESCRIPTION
 DataGrid: Add pager localization and page size options

  - Add PagerRowsPerPageString, PagerInfoFormat, PagerAllItemsText parameters
  - Add PagerPageSizeOptions parameter (defaults to 10, 25, 50, 100)
  - Fix GetPager() to respect PagerContent override
  - Add LocalizedPagerGrid demo example

Closes #14 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive UI-component API changes with limited behavioral impact beyond pager rendering and configuration.
> 
> **Overview**
> Adds new `HUIDataGrid` parameters to localize and configure the built-in pager (`PagerRowsPerPageString`, `PagerInfoFormat`, `PagerAllItemsText`) and to control the page-size dropdown via `PagerPageSizeOptions` (defaulting to 10/25/50/100, with support for `int.MaxValue` as “All”).
> 
> Fixes `GetPager()` so `PagerContent` properly overrides the default pager, and wires the new parameters through to `MudDataGridPager`. Updates the demo page with a new `LocalizedPagerGrid` example and bumps package version to `1.1.2`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c76dcdf39752dafda0233c201c477d62b696bac3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->